### PR TITLE
Better handling of null values

### DIFF
--- a/lib/pg-hoff-results-view.coffee
+++ b/lib/pg-hoff-results-view.coffee
@@ -84,10 +84,14 @@ class PgHoffResultsView
 
     createTd: (text, typeName) ->
         td = document.createElement('td')
-        try
-            td.textContent = @cellText(text, typeName)
-        catch err
-            console.error 'Could not format as ' + typeName, text
+        if text is null
+            td.className = 'null'
+            td.textContent =atom.config.get('pg-hoff.nullString')
+        else
+            try
+                td.textContent = @cellText(text, typeName)
+            catch err
+                console.error 'Could not format as ' + typeName, text
         td.setAttribute 'title', text
         return td
 

--- a/lib/pg-hoff.coffee
+++ b/lib/pg-hoff.coffee
@@ -66,6 +66,11 @@ module.exports = PgHoff =
             description: 'Alias of database connection to use for new tabs</br>Leave blank for no automatic connection'
             default: ''
             order: 10
+        nullString:
+            type: 'string'
+            description: 'Representation of null values'
+            default: 'NULL'
+            order: 11
 
     activate: (state) ->
         console.debug 'Activating the greatest plugin ever..'

--- a/styles/pg-hoff.less
+++ b/styles/pg-hoff.less
@@ -7,6 +7,8 @@
 
 @pg-hoff-cell-background: @base-background-color;
 @pg-hoff-cell-color: @text-color-highlight;
+@pg-hoff-null-background: @pg-hoff-cell-color;
+@pg-hoff-null-color: @pg-hoff-cell-background;
 @pg-hoff-header-color: @text-color-subtle;
 @pg-hoff-header-background: darken(@base-background-color, 10%);
 
@@ -107,6 +109,10 @@
                         border-bottom: 1px solid @pg-hoff-border-color;
                     }
                 }
+                td.null {
+                    background: @pg-hoff-null-background;
+                    color: @pg-hoff-null-color;
+                }
                 th,td {
                     &:last-child {
                         border-right: none;
@@ -117,6 +123,7 @@
                     border-bottom: 1px solid @pg-hoff-border-color;
                     border-right: 1px solid @pg-hoff-border-color;
                     padding: 6px 6px 3px 6px;
+                    height: 27px;
                 }
             }
         }


### PR DESCRIPTION
Set `tr` height so that null-only rows don't get squashed.
Add some styling to null cells.
