### PR TITLE
Add somewhat buggy start-server functionality

### DIFF
--- a/lib/pg-hoff-list-servers-view.coffee
+++ b/lib/pg-hoff-list-servers-view.coffee
@@ -1,6 +1,7 @@
 Promise = require('promise')
 PgHoffDialog = require('./pg-hoff-dialog')
 PgHoffServerRequest     = require './pg-hoff-server-request'
+{maybeStartServer}      = require './pg-hoff-util'
 
 class PgHoffListServersView
     fulfil: null
@@ -13,7 +14,9 @@ class PgHoffListServersView
     connect: (panel) ->
         listServersView = @
         selectedServer = null
-        return PgHoffServerRequest.Get 'listservers'
+        maybeStartServer()
+            .then (servers) ->
+                return PgHoffServerRequest.Get 'listservers'
             .then (servers) ->
                 promise = listServersView.update(servers, listServersView.element)
                 panel.show()

--- a/lib/pg-hoff-util.coffee
+++ b/lib/pg-hoff-util.coffee
@@ -1,0 +1,26 @@
+Promise = require('promise')
+{exec, execSync} = require('child_process')
+
+maybeStartServer = ->
+    return new Promise (fulfil, reject) ->
+        if -1 == atom.config.get('pg-hoff.host').indexOf 'localhost'
+            return fulfil()
+        alreadyRunning = ->
+            try
+                res = execSync('pgrep -f pghoffserver')
+            catch error
+                return false
+            return true
+        if alreadyRunning()
+            return fulfil()
+        exec('pghoffserver')
+        checkIfDone = (timer) =>
+            if alreadyRunning()
+                return fulfil()
+            if timer > 1000
+                return reject()
+            setTimeout((() => checkIfDone(timer + 50)), 50)
+        checkIfDone 0
+
+module.exports =
+    'maybeStartServer': maybeStartServer


### PR DESCRIPTION
When trying to connect, start pghoffserver if it's not already running.

I couldn't get it to then actually connect as well, so after ctrl-z-starting pghoffserver, you have to ctrl-z again to actually connect. Someone who understands more than me about promises/coffeescript/whatever should fix that, because I'm utterly confused.